### PR TITLE
修复清理重复文件功能会把非当前管理员的文件数据库记录全部删除的问题

### DIFF
--- a/plugin/think-plugs-admin/src/controller/File.php
+++ b/plugin/think-plugs-admin/src/controller/File.php
@@ -109,7 +109,7 @@ class File extends Controller
     public function distinct()
     {
         $map = ['uuid' => AdminService::getUserId()];
-        $db1 = SystemFile::mk()->fieldRaw('max(id) id')->where($map)->group('type,xkey');
+        $db1 = SystemFile::mk()->fieldRaw('max(id) id')->group('type,xkey');
         $db2 = $this->app->db->table($db1->buildSql())->alias('dt')->field('id');
         SystemFile::mk()->whereRaw("id not in {$db2->buildSql()}")->delete();
         SystemFile::mk()->where($map)->where(['status' => 1])->delete();


### PR DESCRIPTION
 #8 ThinkPlugsAdmin 后台的清理重复文件会把非当前管理员的文件数据库记录全部删除，包括唯一记录

问题出在查询重复ID时限制了uuid，执行删除命令是却未限制uuid。
需要统一条件，我觉得既然是清理系统内的重复记录，不应该限制uuid。