### PR TITLE
fix: 修复清理重复文件功能会把非当前管理员的文件数据库记录全部删除的问题

### DIFF
--- a/plugin/think-plugs-admin/src/controller/File.php
+++ b/plugin/think-plugs-admin/src/controller/File.php
@@ -108,10 +108,10 @@ class File extends Controller
      */
     public function distinct()
     {
-        $map = ['uuid' => AdminService::getUserId()];
+        $map = ['issafe' => 0, 'uuid' => AdminService::getUserId()];
         $db1 = SystemFile::mk()->fieldRaw('max(id) id')->where($map)->group('type,xkey');
         $db2 = $this->app->db->table($db1->buildSql())->alias('dt')->field('id');
-        SystemFile::mk()->whereRaw("id not in {$db2->buildSql()}")->delete();
+        SystemFile::mk()->where($map)->whereRaw("id not in {$db2->buildSql()}")->delete();
         SystemFile::mk()->where($map)->where(['status' => 1])->delete();
         $this->success('清理重复文件成功！');
     }


### PR DESCRIPTION
fix: 修复 #8 
1、不处理安全模式上传的文件，因为文件管理列表未显示
2、不删除其他人的文件记录