### PR TITLE
fix: 修复str_pad方法并不会补充=号的小问题

### DIFF
--- a/plugin/think-library/src/extend/CodeExtend.php
+++ b/plugin/think-library/src/extend/CodeExtend.php
@@ -143,7 +143,7 @@ class CodeExtend
      */
     public static function deSafe64(string $text): string
     {
-        return base64_decode(str_pad(strtr($text, '-_', '+/'), strlen($text) % 4, '='));
+        return base64_decode(str_pad(strtr($text, '-_', '+/'), (int) (ceil(strlen($text) / 4) * 4), '='));
     }
 
     /**


### PR DESCRIPTION
因为 strlen($text) % 4 取模结果只可能小于4，所以str_pad基本上不进行任何操作。
方法能正确解码的原因是，PHP在大部分情况下能自己处理补位等号。