### PR TITLE
fix: 修复手机短信管理业务场景字段的模板处理问题

### DIFF
--- a/plugin/think-plugs-account/src/view/message/index.html
+++ b/plugin/think-plugs-account/src/view/message/index.html
@@ -9,17 +9,11 @@
 {block name="content"}
 <div class="think-box-shadow">
     {include file='message/index_search'}
-    <label class="layui-hide"><textarea id="SecensData">{$secens|default=''|json_encode}</textarea></label>
+    <label class="layui-hide"><textarea id="ScenesData">{$scenes|default=''|json_encode}</textarea></label>
     <table id="MessageData" data-url="{:sysuri()}"></table>
     <script>
-
-        let secens = JSON.parse(document.getElementById('SecensData').value || '{}');
-
-        function showScene(scene) {
-            return secens[scene] || scene;
-        }
-
         $(function () {
+            let scenes = JSON.parse(document.getElementById('ScenesData').value || '{}');
             $('#MessageData').layTable({
                 even: true, height: 'full', loading: true,
                 sort: {field: 'id', type: 'desc'},
@@ -28,7 +22,11 @@
                     {field: 'smsid', title: '消息编号', sort: true, minWidth: 100, width: '12%', align: 'center'},
                     {field: 'type', title: '短信类型', sort: true, minWidth: 90, width: '8%', align: 'center'},
                     {field: 'phone', title: '发送手机', sort: true, minWidth: 100, width: '10%', align: 'center'},
-                    {field: 'scene', title: '业务场景', align: 'center', minWidth: 100, width: '8%', templet: '<div>{{-showScene(d.scene_name)}}</div>'},
+                    {
+                        field: 'scene', title: '业务场景', align: 'center', minWidth: 100, width: '8%', templet: function(d) {
+                            return scenes[d.scene] || d.scene_name;
+                        }
+                    },
                     {field: 'params', title: '短信内容', align: 'center'},
                     {field: 'result', title: '返回结果', align: 'center'},
                     {


### PR DESCRIPTION
修复下面两个问题：
1、打开手机短信管理页面后，切换到其他页面，再切换回手机短信管理页面会出现 let 重复声明问题。
<img width="590" height="191" alt="wechat_2025-08-12_170047_694" src="https://github.com/user-attachments/assets/3bde39d3-d942-4c6e-b53d-551090c6b956" />
2、变量名拼写错误。