### PR TITLE
Trim inputs and enable strict checks in str2arr/arr2str; preserve trimmed values

### DIFF
--- a/plugin/think-library/src/common.php
+++ b/plugin/think-library/src/common.php
@@ -201,8 +201,9 @@ if (!function_exists('str2arr')) {
     {
         $items = [];
         foreach (explode($separ, trim($text, $separ)) as $item) {
-            if ($item !== '' && (!is_array($allow) || in_array($item, $allow))) {
-                $items[] = trim($item);
+            $item = trim($item);
+            if ($item !== '' && (!is_array($allow) || in_array($item, $allow, true))) {
+                $items[] = $item;
             }
         }
         return $items;
@@ -218,8 +219,11 @@ if (!function_exists('arr2str')) {
     function arr2str(array $data, string $separ = ',', ?array $allow = null): string
     {
         foreach ($data as $key => $item) {
-            if ($item === '' || (is_array($allow) && !in_array($item, $allow))) {
+            $item = is_string($item) ? trim($item) : $item;
+            if ($item === '' || (is_array($allow) && !in_array($item, $allow, true))) {
                 unset($data[$key]);
+            } else {
+                $data[$key] = $item;
             }
         }
         return $separ . join($separ, $data) . $separ;


### PR DESCRIPTION
### Motivation

- Fix trimming and type-coercion issues when converting between strings and arrays to avoid unexpected empty entries or incorrect matches.

### Description

- In `str2arr` trim each exploded item before validation and use `in_array` with strict comparison by passing `true` as the third argument.
- In `arr2str` trim items only when they are strings and use `in_array` with strict comparison to determine allowed values.
- In `arr2str` remove empty or disallowed entries while preserving and writing back trimmed values for valid items.

### Testing

- Ran the repository PHP linting and static analysis checks and they completed without errors.
- Executed the plugin unit test suite covering array/string helpers and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c6d297d8832eb82a80b88bb9f489)