### PR TITLE
fix(think-library): 修复函数文件重复加载问题

### DIFF
--- a/plugin/think-library/src/Library.php
+++ b/plugin/think-library/src/Library.php
@@ -104,10 +104,10 @@ class Library extends Service
      * 动态加载文件.
      * @return mixed
      */
-    public static function load(string $file)
+    public static function load(string $file, bool $once = false)
     {
         try {
-            return include $file;
+            return $once ? include_once $file : include $file;
         } catch (\Error|\Throwable $error) {
             trace_file($error);
             throw new HttpException(500, $error->getMessage());
@@ -122,10 +122,10 @@ class Library extends Service
         // 动态加载全局配置
         [$dir, $ext] = [$this->app->getBasePath(), $this->app->getConfigExt()];
         ToolsExtend::find($dir, 2, function (\SplFileInfo $info) use ($ext) {
-            $info->isFile() && $info->getBasename() === "sys{$ext}" && Library::load($info->getPathname());
+            $info->isFile() && $info->getBasename() === "sys{$ext}" && Library::load($info->getPathname(), true);
         });
         if (is_file($file = "{$dir}common{$ext}")) {
-            Library::load($file);
+            Library::load($file, true);
         }
         if (is_file($file = "{$dir}provider{$ext}")) {
             $this->app->bind(include $file);

--- a/plugin/think-library/src/support/middleware/MultAccess.php
+++ b/plugin/think-library/src/support/middleware/MultAccess.php
@@ -168,7 +168,7 @@ class MultAccess
         [$ext, $fmaps] = [$this->app->getConfigExt(), []];
         // 加载应用函数文件
         if (is_file($file = "{$appPath}common{$ext}")) {
-            Library::load($file);
+            Library::load($file, true);
         }
         // 加载应用配置文件
         ToolsExtend::find($appPath . 'config', 1, function (\SplFileInfo $info) use ($ext) {


### PR DESCRIPTION
#16 ThinkLibrary v6.1.92 动态加载文件使用 include 方式导致文件重复加载

因为ThinkPHP核心框架默认会加载app/common.php，ThinkAdmin核心框架也会自动加载app/common.php，使用include方式加载文件会导致文件重复加载，app/common.php以及app/sys.php文件作为全局函数文件，文件内容可能会包含自定义函数和常量，理应只加载一次，重复加载会报错。