### PR TITLE
fix(think-library): 修复全局中间件导入类型错误的问题

### DIFF
--- a/plugin/think-library/src/Library.php
+++ b/plugin/think-library/src/Library.php
@@ -134,7 +134,7 @@ class Library extends Service
             $this->app->loadEvent(include $file);
         }
         if (is_file($file = "{$dir}middleware{$ext}")) {
-            $this->app->middleware->import(include $file, 'app');
+            $this->app->middleware->import(include $file);
         }
 
         // 终端 HTTP 访问时特殊处理


### PR DESCRIPTION
因为ThinkPHP和ThinkAdmin都会自动加载并导入app/middleware.php中定义的全局中间件，且因为ThinkAdmin错误的将其导入为应用中间件导致无法排重，所以app/middleware.php中定义的全局中间件会被执行两次，这将导致不可预测的错误。